### PR TITLE
Protect admin routes with new eloquent sessions

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use Illuminate\View\View;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\RedirectResponse;
 
@@ -39,5 +38,32 @@ class AuthController extends Controller
         }
 
         return redirect()->route('login');
+    }
+
+    /**
+     * Show the form to logout a user.
+     *
+     * @return \Illuminate\View\View|\Illuminate\Http\RedirectResponse
+     */
+    public function showLogout()
+    {
+        if (Auth::check() === false) {
+            // The user is not logged in, just redirect them home
+            return redirect('/');
+        }
+
+        return view('logout');
+    }
+
+    /**
+     * Log the user out from their current session.
+     *
+     * @return \Illuminate\Http\RedirectResponse;
+     */
+    public function logout(): RedirectResponse
+    {
+        Auth::logout();
+
+        return redirect('/');
     }
 }

--- a/app/Http/Middleware/MyAuthMiddleware.php
+++ b/app/Http/Middleware/MyAuthMiddleware.php
@@ -6,6 +6,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class MyAuthMiddleware
 {
@@ -18,7 +19,7 @@ class MyAuthMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
-        if ($request->session()->has('loggedin') !== true) {
+        if (Auth::check($request->user()) == false) {
             //they’re not logged in, so send them to login form
             return redirect()->route('login');
         }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Str;
 use Faker\Generator as Faker;
 
 /*
@@ -12,12 +13,12 @@ use Faker\Generator as Faker;
 | model instances for testing / seeding your application's database.
 |
 */
-$factory->define(App\User::class, function (Faker $faker) {
+$factory->define(App\Models\User::class, function (Faker $faker) {
     static $password;
+
     return [
-        'name' => $faker->name,
-        'email' => $faker->unique()->safeEmail,
+        'name' => mb_strtolower($faker->firstName),
         'password' => $password ?: $password = bcrypt('secret'),
-        'remember_token' => str_random(10),
+        'remember_token' => Str::random(10),
     ];
 });

--- a/resources/views/logout.blade.php
+++ b/resources/views/logout.blade.php
@@ -1,0 +1,10 @@
+@extends('master')
+@section('title')Logout @stop
+
+@section('content')
+    <h2>Logout</h2>
+    <form action="logout" method="post">
+        <input type="hidden" name="_token" value="{{ csrf_token() }}">
+        <input type="submit" name="submit" value="Logout">
+    </form>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,17 +14,21 @@
 Route::group(['domain' => config('url.longurl')], function () {
     Route::get('/', 'NotesController@index');
 
-    //Static project page
+    // Static project page
     Route::view('projects', 'projects');
 
-    //Static colophon page
+    // Static colophon page
     Route::view('colophon', 'colophon');
 
-    //The login routes to get authe'd for admin
+    // The login routes to get auth'd for admin
     Route::get('login', 'AuthController@showLogin')->name('login');
     Route::post('login', 'AuthController@login');
 
-    //Admin pages grouped for filter
+    // And the logout routes
+    Route::get('logout', 'AuthController@showLogout')->name('logout');
+    Route::post('logout', 'AuthController@logout');
+
+    // Admin pages grouped for filter
     Route::group([
         'middleware' => 'myauth',
         'namespace' => 'Admin',
@@ -42,7 +46,7 @@ Route::group(['domain' => config('url.longurl')], function () {
             Route::delete('/{id}', 'ArticlesController@destroy');
         });
 
-        //Notes
+        // Notes
         Route::group(['prefix' => 'notes'], function () {
             Route::get('/', 'NotesController@index');
             Route::get('/create', 'NotesController@create');
@@ -52,7 +56,7 @@ Route::group(['domain' => config('url.longurl')], function () {
             Route::delete('/{id}', 'NotesController@destroy');
         });
 
-        //Micropub Clients
+        // Micropub Clients
         Route::group(['prefix' => 'clients'], function () {
             Route::get('/', 'ClientsController@index');
             Route::get('/create', 'ClientsController@create');
@@ -62,7 +66,7 @@ Route::group(['domain' => config('url.longurl')], function () {
             Route::delete('/{id}', 'ClientsController@destroy');
         });
 
-        //Contacts
+        // Contacts
         Route::group(['prefix' => 'contacts'], function () {
             Route::get('/', 'ContactsController@index');
             Route::get('/create', 'ContactsController@create');
@@ -73,7 +77,7 @@ Route::group(['domain' => config('url.longurl')], function () {
             Route::get('/{id}/getavatar', 'ContactsController@getAvatar');
         });
 
-        //Places
+        // Places
         Route::group(['prefix' => 'places'], function () {
             Route::get('/', 'PlacesController@index');
             Route::get('/create', 'PlacesController@create');
@@ -86,7 +90,7 @@ Route::group(['domain' => config('url.longurl')], function () {
             Route::delete('/{id}', 'PlacesController@destroy');
         });
 
-        //Likes
+        // Likes
         Route::group(['prefix' => 'likes'], function () {
             Route::get('/', 'LikesController@index');
             Route::get('/create', 'LikesController@create');
@@ -97,7 +101,7 @@ Route::group(['domain' => config('url.longurl')], function () {
         });
     });
 
-    //Blog pages using ArticlesController
+    // Blog pages using ArticlesController
     Route::group(['prefix' => 'blog'], function () {
         Route::get('/feed.rss', 'FeedsController@blogRss');
         Route::get('/feed.atom', 'FeedsController@blogAtom');
@@ -107,7 +111,7 @@ Route::group(['domain' => config('url.longurl')], function () {
         Route::get('/{year}/{month}/{slug}', 'ArticlesController@show');
     });
 
-    //Notes pages using NotesController
+    // Notes pages using NotesController
     Route::group(['prefix' => 'notes'], function () {
         Route::get('/', 'NotesController@index');
         Route::get('/feed.rss', 'FeedsController@notesRss');
@@ -139,15 +143,15 @@ Route::group(['domain' => config('url.longurl')], function () {
     Route::post('api/media', 'MicropubController@media')->middleware('micropub.token', 'cors')->name('media-endpoint');
     Route::options('/api/media', 'MicropubController@mediaOptionsResponse')->middleware('cors');
 
-    //webmention
+    // Webmention
     Route::get('webmention', 'WebMentionsController@get');
     Route::post('webmention', 'WebMentionsController@receive');
 
-    //Contacts
+    // Contacts
     Route::get('contacts', 'ContactsController@index');
     Route::get('contacts/{nick}', 'ContactsController@show');
 
-    //Places
+    // Places
     Route::get('places', 'PlacesController@index');
     Route::get('places/{slug}', 'PlacesController@show');
 
@@ -156,7 +160,7 @@ Route::group(['domain' => config('url.longurl')], function () {
     Route::post('update-colour-scheme', 'SessionStoreController@saveColour');
 });
 
-//Short URL
+// Short URL
 Route::group(['domain' => config('url.shorturl')], function () {
     Route::get('/', 'ShortURLsController@baseURL');
     Route::get('@', 'ShortURLsController@twitter');

--- a/tests/Feature/Admin/AdminHomeControllerTest.php
+++ b/tests/Feature/Admin/AdminHomeControllerTest.php
@@ -3,13 +3,20 @@
 namespace Tests\Feature\Admin;
 
 use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class AdminHomeControllerTest extends TestCase
 {
+    use DatabaseTransactions;
+
     public function test_admin_homepage()
     {
-        $response = $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)
                          ->get('/admin');
+
         $response->assertViewIs('admin.welcome');
     }
 }

--- a/tests/Feature/Admin/ArticlesTest.php
+++ b/tests/Feature/Admin/ArticlesTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Admin;
 
 use Tests\TestCase;
+use App\Models\User;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -12,21 +13,27 @@ class ArticlesTest extends TestCase
 
     public function test_index_page()
     {
-        $response = $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)
                          ->get('/admin/blog');
         $response->assertSeeText('Select article to edit:');
     }
 
     public function test_create_page()
     {
-        $response = $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)
                          ->get('/admin/blog/create');
         $response->assertSeeText('Title (URL)');
     }
 
     public function test_create_new_article()
     {
-        $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)
              ->post('/admin/blog', [
                  'title' => 'Test Title',
                  'main' => 'Article content'
@@ -36,6 +43,7 @@ class ArticlesTest extends TestCase
 
     public function test_create_new_article_with_upload()
     {
+        $user = factory(User::class)->create();
         $faker = \Faker\Factory::create();
         $text = $faker->text;
         if ($fh = fopen(sys_get_temp_dir() . '/article.md', 'w')) {
@@ -45,7 +53,7 @@ class ArticlesTest extends TestCase
         $path = sys_get_temp_dir() . '/article.md';
         $file = new UploadedFile($path, 'article.md', 'text/plain', filesize($path), null, true);
 
-        $this->withSession(['loggedin' => true])
+        $this->actingAs($user)
              ->post('/admin/blog', [
                 'title' => 'Uploaded Article',
                 'article' => $file,
@@ -59,14 +67,18 @@ class ArticlesTest extends TestCase
 
     public function test_see_edit_form()
     {
-        $response = $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)
                          ->get('/admin/blog/1/edit');
         $response->assertSeeText('This is *my* new blog. It uses `Markdown`.');
     }
 
     public function test_edit_article()
     {
-        $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)
              ->post('/admin/blog/1', [
                  '_method' => 'PUT',
                  'title' => 'My New Blog',
@@ -80,7 +92,9 @@ class ArticlesTest extends TestCase
 
     public function test_delete_article()
     {
-        $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)
              ->post('/admin/blog/1', [
                  '_method' => 'DELETE',
              ]);

--- a/tests/Feature/Admin/ClientsTest.php
+++ b/tests/Feature/Admin/ClientsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Admin;
 
 use Tests\TestCase;
+use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class ClientsTest extends TestCase
@@ -11,21 +12,27 @@ class ClientsTest extends TestCase
 
     public function test_index_page()
     {
-        $response = $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)
                          ->get('/admin/clients');
         $response->assertSeeText('Clients');
     }
 
     public function test_create_page()
     {
-        $response = $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)
                          ->get('/admin/clients/create');
         $response->assertSeeText('New Client');
     }
 
     public function test_create_new_client()
     {
-        $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)
              ->post('/admin/clients', [
                  'client_name' => 'Micropublish',
                  'client_url' => 'https://micropublish.net'
@@ -38,14 +45,18 @@ class ClientsTest extends TestCase
 
     public function test_see_edit_form()
     {
-        $response = $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)
                          ->get('/admin/clients/1/edit');
         $response->assertSee('https://jbl5.dev/notes/new');
     }
 
     public function test_edit_client()
     {
-        $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)
              ->post('/admin/clients/1', [
                  '_method' => 'PUT',
                  'client_url' => 'https://jbl5.dev/notes/new',
@@ -59,7 +70,9 @@ class ClientsTest extends TestCase
 
     public function test_delete_client()
     {
-        $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)
              ->post('/admin/clients/1', [
                  '_method' => 'DELETE',
              ]);

--- a/tests/Feature/Admin/ContactsTest.php
+++ b/tests/Feature/Admin/ContactsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Admin;
 
 use Tests\TestCase;
+use App\Models\User;
 use GuzzleHttp\Client;
 use App\Models\Contact;
 use GuzzleHttp\HandlerStack;
@@ -26,25 +27,25 @@ class ContactsTest extends TestCase
 
     public function test_index_page()
     {
-        $response = $this->withSession([
-            'loggedin' => true
-        ])->get('/admin/contacts');
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->get('/admin/contacts');
         $response->assertViewIs('admin.contacts.index');
     }
 
     public function test_create_page()
     {
-        $response = $this->withSession([
-            'loggedin' => true
-        ])->get('/admin/contacts/create');
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->get('/admin/contacts/create');
         $response->assertViewIs('admin.contacts.create');
     }
 
     public function test_create_new_contact()
     {
-        $this->withSession([
-            'loggedin' => true
-        ])->post('/admin/contacts', [
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)->post('/admin/contacts', [
             'name' => 'Fred Bloggs',
             'nick' => 'fred',
             'homepage' => 'https://fred.blog/gs',
@@ -58,17 +59,17 @@ class ContactsTest extends TestCase
 
     public function test_see_edit_form()
     {
-        $response = $this->withSession([
-            'loggedin' => true
-        ])->get('/admin/contacts/1/edit');
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->get('/admin/contacts/1/edit');
         $response->assertViewIs('admin.contacts.edit');
     }
 
     public function test_update_contact_no_uploaded_avatar()
     {
-        $this->withSession([
-            'loggedin' => true
-        ])->post('/admin/contacts/1', [
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)->post('/admin/contacts/1', [
             '_method' => 'PUT',
             'name' => 'Tantek Celik',
             'nick' => 'tantek',
@@ -86,9 +87,9 @@ class ContactsTest extends TestCase
         copy(__DIR__ . '/../../aaron.png', sys_get_temp_dir() . '/tantek.png');
         $path = sys_get_temp_dir() . '/tantek.png';
         $file = new UploadedFile($path, 'tantek.png', 'image/png', filesize($path), null, true);
-        $this->withSession([
-            'loggedin' => true
-        ])->post('/admin/contacts/1', [
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)->post('/admin/contacts/1', [
             '_method' => 'PUT',
             'name' => 'Tantek Celik',
             'nick' => 'tantek',
@@ -104,9 +105,9 @@ class ContactsTest extends TestCase
 
     public function test_delete_contact()
     {
-        $this->withSession([
-            'loggedin' => true
-        ])->post('/admin/contacts/1', [
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)->post('/admin/contacts/1', [
             '_method' => 'DELETE',
         ]);
         $this->assertDatabaseMissing('contacts', [
@@ -129,10 +130,9 @@ HTML;
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
         $this->app->instance(Client::class, $client);
+        $user = factory(User::class)->create();
 
-        $response = $this->withSession([
-            'loggedin' => true,
-        ])->get('/admin/contacts/1/getavatar');
+        $this->actingAs($user)->get('/admin/contacts/1/getavatar');
 
         $this->assertFileEquals(
             __DIR__ . '/../../aaron.png',
@@ -148,10 +148,9 @@ HTML;
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
         $this->app->instance(Client::class, $client);
+        $user = factory(User::class)->create();
 
-        $response = $this->withSession([
-            'loggedin' => true,
-        ])->get('/admin/contacts/1/getavatar');
+        $response = $this->actingAs($user)->get('/admin/contacts/1/getavatar');
 
         $response->assertRedirect('/admin/contacts/1/edit');
     }
@@ -170,10 +169,9 @@ HTML;
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
         $this->app->instance(Client::class, $client);
+        $user = factory(User::class)->create();
 
-        $response = $this->withSession([
-            'loggedin' => true,
-        ])->get('/admin/contacts/1/getavatar');
+        $response = $this->actingAs($user)->get('/admin/contacts/1/getavatar');
 
         $response->assertRedirect('/admin/contacts/1/edit');
     }
@@ -184,10 +182,9 @@ HTML;
             'nick' => 'fred',
             'name' => 'Fred Bloggs',
         ]);
+        $user = factory(User::class)->create();
 
-        $response = $this->withSession([
-            'loggedin' => true,
-        ])->get('/admin/contacts/' . $contact->id . '/getavatar');
+        $response = $this->actingAs($user)->get('/admin/contacts/' . $contact->id . '/getavatar');
 
         $response->assertRedirect('/admin/contacts/' . $contact->id . '/edit');
     }

--- a/tests/Feature/Admin/LikesTest.php
+++ b/tests/Feature/Admin/LikesTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature\Admin;
 
+use App\Models\User;
 use Tests\TestCase;
 use App\Models\Like;
 use App\Jobs\ProcessLike;
 use Illuminate\Support\Facades\Queue;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class LikesTest extends TestCase
@@ -15,14 +15,18 @@ class LikesTest extends TestCase
 
     public function test_index_page()
     {
-        $response = $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)
                          ->get('/admin/likes');
         $response->assertSeeText('Likes');
     }
 
     public function test_create_page()
     {
-        $response = $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)
                          ->get('/admin/likes/create');
         $response->assertSeeText('New Like');
     }
@@ -30,7 +34,9 @@ class LikesTest extends TestCase
     public function test_create_new_like()
     {
         Queue::fake();
-        $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)
              ->post('/admin/likes', [
                  'like_url' => 'https://example.com'
              ]);
@@ -42,7 +48,9 @@ class LikesTest extends TestCase
 
     public function test_see_edit_form()
     {
-        $response = $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)
                          ->get('/admin/likes/1/edit');
         $response->assertSee('Edit Like');
     }
@@ -50,7 +58,9 @@ class LikesTest extends TestCase
     public function test_edit_like()
     {
         Queue::fake();
-        $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)
              ->post('/admin/likes/1', [
                  '_method' => 'PUT',
                  'like_url' => 'https://example.com',
@@ -65,7 +75,9 @@ class LikesTest extends TestCase
     {
         $like = Like::find(1);
         $url = $like->url;
-        $this->withSession(['loggedin' => true])
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)
              ->post('/admin/likes/1', [
                  '_method' => 'DELETE',
              ]);

--- a/tests/Feature/Admin/NotesTest.php
+++ b/tests/Feature/Admin/NotesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Admin;
 
+use App\Models\User;
 use Tests\TestCase;
 use App\Jobs\SendWebMentions;
 use Illuminate\Support\Facades\Queue;
@@ -13,25 +14,25 @@ class NotesTest extends TestCase
 
     public function test_index_page()
     {
-        $response = $this->withSession([
-            'loggedin' => true,
-        ])->get('/admin/notes');
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->get('/admin/notes');
         $response->assertViewIs('admin.notes.index');
     }
 
     public function test_create_page()
     {
-        $response = $this->withSession([
-            'loggedin' => true,
-        ])->get('/admin/notes/create');
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->get('/admin/notes/create');
         $response->assertViewIs('admin.notes.create');
     }
 
     public function test_create_a_new_note()
     {
-        $this->withSession([
-            'loggedin' => true,
-        ])->post('/admin/notes', [
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)->post('/admin/notes', [
             'content' => 'A new test note',
         ]);
         $this->assertDatabaseHas('notes', [
@@ -41,19 +42,18 @@ class NotesTest extends TestCase
 
     public function test_edit_page()
     {
-        $response = $this->withSession([
-            'loggedin' => true,
-        ])->get('/admin/notes/1/edit');
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->get('/admin/notes/1/edit');
         $response->assertViewIs('admin.notes.edit');
     }
 
     public function test_edit_a_note()
     {
         Queue::fake();
+        $user = factory(User::class)->create();
 
-        $this->withSession([
-            'loggedin' => true,
-        ])->post('/admin/notes/1', [
+        $this->actingAs($user)->post('/admin/notes/1', [
             '_method' => 'PUT',
             'content' => 'An edited note',
             'webmentions' => true,
@@ -67,9 +67,9 @@ class NotesTest extends TestCase
 
     public function test_delete_note()
     {
-        $this->withSession([
-            'loggedin' => true,
-        ])->post('/admin/notes/1', [
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)->post('/admin/notes/1', [
             '_method' => 'DELETE',
         ]);
         $this->assertSoftDeleted('notes', [

--- a/tests/Feature/Admin/PlacesTest.php
+++ b/tests/Feature/Admin/PlacesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Admin;
 
+use App\Models\User;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -11,25 +12,25 @@ class PlacesTest extends TestCase
 
     public function test_index_page()
     {
-        $response = $this->withSession([
-            'loggedin' => true,
-        ])->get('/admin/places');
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->get('/admin/places');
         $response->assertViewIs('admin.places.index');
     }
 
     public function test_create_page()
     {
-        $response = $this->withSession([
-            'loggedin' => true,
-        ])->get('/admin/places/create');
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->get('/admin/places/create');
         $response->assertViewIs('admin.places.create');
     }
 
     public function test_create_new_place()
     {
-        $this->withSession([
-            'loggedin' => true,
-        ])->post('/admin/places', [
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)->post('/admin/places', [
             'name' => 'Test Place',
             'description' => 'A dummy place for feature tests',
             'latitude' => '1.23',
@@ -43,17 +44,17 @@ class PlacesTest extends TestCase
 
     public function test_edit_page()
     {
-        $response = $this->withSession([
-            'loggedin' => true,
-        ])->get('/admin/places/1/edit');
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->get('/admin/places/1/edit');
         $response->assertViewIs('admin.places.edit');
     }
 
     public function test_updating_a_place()
     {
-        $this->withSession([
-            'loggedin' => true,
-        ])->post('/admin/places/1', [
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user)->post('/admin/places/1', [
             '_method' => 'PUT',
             'name' => 'The Bridgewater',
             'description' => 'Who uses “Pub” anyway',


### PR DESCRIPTION
When using Laravel’s own auth middleware an exception would then get
thrown which was being sent to Slack, hmmm.

So I modified the original MyAuthMiddleware to use the Auth facade
instead of a custom session key.

A logout page has also been added.

Closes issue #110