### PR TITLE
Return null for media endpoint when no media exists

### DIFF
--- a/app/Http/Controllers/MicropubMediaController.php
+++ b/app/Http/Controllers/MicropubMediaController.php
@@ -58,7 +58,7 @@ class MicropubMediaController extends Controller
             try {
                 $media = Media::latest()->whereDate('created_at', '>=', Carbon::now()->subMinutes(30))->firstOrFail();
             } catch (ModelNotFoundException $exception) {
-                return response()->json([], 404);
+                return response()->json(['url' => null]);
             }
 
             return response()->json(['url' => $media->url]);

--- a/tests/Feature/MicropubMediaTest.php
+++ b/tests/Feature/MicropubMediaTest.php
@@ -28,7 +28,8 @@ class MicropubMediaTest extends TestCase
             '/api/media?q=last',
             ['HTTP_Authorization' => 'Bearer ' . $this->getToken()]
         );
-        $response->assertStatus(404);
+        $response->assertStatus(200);
+        $response->assertJson(['url' => null]);
     }
 
     /** @test */


### PR DESCRIPTION
Instead of 404, return 200 with URL set to null in body.