### PR TITLE
Increase article title and URL column length in migration.

### DIFF
--- a/database/migrations/2023_05_19_131031_alter_article_column_lengths.php
+++ b/database/migrations/2023_05_19_131031_alter_article_column_lengths.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->string('titleurl', 255)->change();
+            $table->string('url', 255)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            // Converting back to shorter lengths might cause issues
+        });
+    }
+};


### PR DESCRIPTION
- Increase character lengths for `titleurl` and `url` columns in `articles` table
- Add migration file to alter column lengths in database