### PR TITLE
fix: Use correct config variables post L10-config update

### DIFF
--- a/app/Http/Controllers/FeedsController.php
+++ b/app/Http/Controllers/FeedsController.php
@@ -71,7 +71,7 @@ class FeedsController extends Controller
         $articles = Article::where('published', '1')->latest('updated_at')->take(20)->get();
         $data = [
             'version' => 'https://jsonfeed.org/version/1',
-            'title' => 'The JSON Feed for ' . config('app.display_name') . '’s blog',
+            'title' => 'The JSON Feed for ' . config('user.display_name') . '’s blog',
             'home_page_url' => config('app.url') . '/blog',
             'feed_url' => config('app.url') . '/blog/feed.json',
             'items' => [],
@@ -86,7 +86,7 @@ class FeedsController extends Controller
                 'date_published' => $article->created_at->tz('UTC')->toRfc3339String(),
                 'date_modified' => $article->updated_at->tz('UTC')->toRfc3339String(),
                 'author' => [
-                    'name' => config('app.display_name'),
+                    'name' => config('user.display_name'),
                 ],
             ];
         }
@@ -102,7 +102,7 @@ class FeedsController extends Controller
         $notes = Note::latest()->with('media')->take(20)->get();
         $data = [
             'version' => 'https://jsonfeed.org/version/1',
-            'title' => 'The JSON Feed for ' . config('app.display_name') . '’s notes',
+            'title' => 'The JSON Feed for ' . config('user.display_name') . '’s notes',
             'home_page_url' => config('app.url') . '/notes',
             'feed_url' => config('app.url') . '/notes/feed.json',
             'items' => [],
@@ -116,7 +116,7 @@ class FeedsController extends Controller
                 'date_published' => $note->created_at->tz('UTC')->toRfc3339String(),
                 'date_modified' => $note->updated_at->tz('UTC')->toRfc3339String(),
                 'author' => [
-                    'name' => config('app.display_name'),
+                    'name' => config('user.display_name'),
                 ],
             ];
         }
@@ -151,7 +151,7 @@ class FeedsController extends Controller
             'url' => url('/blog'),
             'author' => [
                 'type' => 'card',
-                'name' => config('user.displayname'),
+                'name' => config('user.display_name'),
                 'url' => config('url.longurl'),
             ],
             'children' => $items,
@@ -187,7 +187,7 @@ class FeedsController extends Controller
             'url' => url('/notes'),
             'author' => [
                 'type' => 'card',
-                'name' => config('user.displayname'),
+                'name' => config('user.display_name'),
                 'url' => config('url.longurl'),
             ],
             'children' => $items,

--- a/config/user.php
+++ b/config/user.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'displayname' => env('DISPLAY_NAME'),
+    'display_name' => env('DISPLAY_NAME'),
 
     'username' => env('USER_NAME'),
 ];

--- a/resources/views/articles/atom.blade.php
+++ b/resources/views/articles/atom.blade.php
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-    <title>Atom feed for {{ config('app.display_name') }}’s blog</title>
+    <title>Atom feed for {{ config('user.display_name') }}’s blog</title>
     <link rel="self" href="{{ config('app.url') }}/blog/feed.atom" />
     <id>{{ config('app.url')}}/blog</id>
     <updated>{{ $articles[0]->updated_at->toAtomString() }}</updated>
@@ -13,7 +13,7 @@
         <updated>{{ $article->updated_at->toAtomString() }}</updated>
         <content>{{ $article->main }}</content>
         <author>
-            <name>{{ config('app.display_name') }}</name>
+            <name>{{ config('user.display_name') }}</name>
         </author>
     </entry>
 @endforeach

--- a/resources/views/articles/rss.blade.php
+++ b/resources/views/articles/rss.blade.php
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
-        <title>{{ config('app.display_name') }}</title>
+        <title>{{ config('user.display_name') }}</title>
         <atom:link href="{{ config('app.url') }}/blog/feed.rss" rel="self" type="application/rss+xml" />
         <description>An RSS feed of the blog posts found on {{ config('url.longurl') }}</description>
         <link>{{ config('app.url') }}/blog</link>

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -2,7 +2,7 @@
 <html lang="en-GB">
     <head>
         <meta charset="UTF-8">
-        <title>@yield('title'){{ config('app.display_name') }}</title>
+        <title>@yield('title'){{ config('app.name') }}</title>
         <meta name="viewport" content="width=device-width">
         @if (!empty(config('app.font_link')))
             <link rel="stylesheet" href="{{ config('app.font_link') }}">
@@ -31,7 +31,7 @@
     <body class="grid">
         <header id="site-header">
             <h1>
-                <a rel="author" href="/">{{ config('app.display_name') }}</a>
+                <a rel="author" href="/">{{ config('user.display_name') }}</a>
             </h1>
             <nav>
                 <a href="/">All</a>

--- a/resources/views/notes/atom.blade.php
+++ b/resources/views/notes/atom.blade.php
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-    <title>Atom feed for {{ config('app.display_name') }}’s notes</title>
+    <title>Atom feed for {{ config('user.display_name') }}’s notes</title>
     <link rel="self" href="{{ config('app.url') }}/notes/feed.atom" />
     <id>{{ config('app.url')}}/notes</id>
     <updated>{{ $notes[0]->updated_at->toAtomString() }}</updated>
@@ -13,7 +13,7 @@
         <updated>{{ $note->updated_at->toAtomString() }}</updated>
         <content type="html">{{ $note->note }}</content>
         <author>
-            <name>{{ config('app.display_name') }}</name>
+            <name>{{ config('user.display_name') }}</name>
         </author>
     </entry>
 @endforeach

--- a/resources/views/notes/rss.blade.php
+++ b/resources/views/notes/rss.blade.php
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
-        <title>{{ config('app.display_name') }}</title>
+        <title>{{ config('user.display_name') }}</title>
         <atom:link href="{{ config('app.url') }}/notes/feed.rss" rel="self" type="application/rss+xml" />
         <description>An RSS feed of the notes found on {{ config('url.longurl') }}</description>
         <link>{{ config('app.url') }}/notes</link>

--- a/tests/Feature/FeedsTest.php
+++ b/tests/Feature/FeedsTest.php
@@ -64,7 +64,7 @@ class FeedsTest extends TestCase
             'url' => url('/blog'),
             'author' => [
                 'type' => 'card',
-                'name' => config('user.displayname'),
+                'name' => config('user.display_name'),
                 'url' => config('url.longurl'),
             ],
             'children' => [[
@@ -125,7 +125,7 @@ class FeedsTest extends TestCase
             'url' => url('/notes'),
             'author' => [
                 'type' => 'card',
-                'name' => config('user.displayname'),
+                'name' => config('user.display_name'),
                 'url' => config('url.longurl'),
             ],
             'children' => [[


### PR DESCRIPTION
Specifically the header name had disappeared.