### PR TITLE
refactor: Refactor and add tests for SaveProfileImage feature

### DIFF
--- a/app/Jobs/SaveProfileImage.php
+++ b/app/Jobs/SaveProfileImage.php
@@ -42,6 +42,14 @@ class SaveProfileImage implements ShouldQueue
         $photo = Arr::get($author, 'properties.photo.0');
         $home = Arr::get($author, 'properties.url.0');
 
+        if (is_array($photo) && array_key_exists('value', $photo)) {
+            $photo = $photo['value'];
+        }
+
+        if (is_array($home)) {
+            $home = array_shift($home);
+        }
+
         //dont save pbs.twimg.com links
         if (
             $photo


### PR DESCRIPTION
- Add error handling checks for photo and home
- Add 3 new tests and modify an existing test for SaveProfileImageJob
- Test getting URL from photo object if alt text is provided
- Test using the first URL if multiple homepages are provided