### PR TITLE
Increase deployment trigger to include published releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,8 @@ name: Deploy
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
- Add workflow trigger for manual release deployment using the `release` event
- Trigger the workflow on `published` release types only