### PR TITLE
Fix issue discovering webmentions endpoints for some sites

### DIFF
--- a/app/Jobs/SendWebMentions.php
+++ b/app/Jobs/SendWebMentions.php
@@ -76,7 +76,7 @@ class SendWebMentions implements ShouldQueue
         //check HTTP Headers for webmention endpoint
         $links = Header::parse($response->getHeader('Link'));
         foreach ($links as $link) {
-            if (mb_stristr($link['rel'], 'webmention')) {
+            if (array_key_exists('rel', $link) && mb_stristr($link['rel'], 'webmention')) {
                 return $this->resolveUri(trim($link[0], '<>'), $url);
             }
         }

--- a/tests/Unit/Jobs/SendWebMentionJobTest.php
+++ b/tests/Unit/Jobs/SendWebMentionJobTest.php
@@ -114,7 +114,8 @@ class SendWebMentionJobTest extends TestCase
     public function linksInNotesCanNotSupportWebmentions(): void
     {
         $mock = new MockHandler([
-            new Response(200),
+            // URLs with commas currently break the parse function I’m using
+            new Response(200, ['Link' => '<https://example.org/foo,bar>; rel="preconnect"']),
         ]);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);


### PR DESCRIPTION
The Guzzle provided Header::parse does not like commas in URLs