### PR TITLE
Save full url during login

### DIFF
--- a/app/Http/Middleware/MyAuthMiddleware.php
+++ b/app/Http/Middleware/MyAuthMiddleware.php
@@ -20,7 +20,7 @@ class MyAuthMiddleware
     {
         if (Auth::check() === false) {
             // they’re not logged in, so send them to login form
-            redirect()->setIntendedUrl($request->url());
+            redirect()->setIntendedUrl($request->fullUrl());
 
             return redirect()->route('login');
         }


### PR DESCRIPTION
This means the query params should be kept when redirecting back to `/auth?...` during the IndieAuth flow.