### PR TITLE
Improve scope checking

### DIFF
--- a/app/Http/Controllers/MicropubController.php
+++ b/app/Http/Controllers/MicropubController.php
@@ -13,7 +13,6 @@ use App\Services\Micropub\UpdateService;
 use App\Services\TokenService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use illuminate\Support\Arr;
 use Lcobucci\JWT\Encoding\CannotDecodeContent;
 use Lcobucci\JWT\Token\InvalidTokenStructure;
 use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
@@ -73,7 +72,7 @@ class MicropubController extends Controller
                 $scopes = explode(' ', $scopes);
             }
 
-            if (!in_array('create', $scopes)) {
+            if (! in_array('create', $scopes)) {
                 $micropubResponses = new MicropubResponses();
 
                 return $micropubResponses->insufficientScopeResponse();
@@ -91,7 +90,7 @@ class MicropubController extends Controller
             if (is_string($scopes)) {
                 $scopes = explode(' ', $scopes);
             }
-            if (!in_array('create', $scopes)) {
+            if (! in_array('create', $scopes)) {
                 $micropubResponses = new MicropubResponses();
 
                 return $micropubResponses->insufficientScopeResponse();
@@ -109,7 +108,7 @@ class MicropubController extends Controller
             if (is_string($scopes)) {
                 $scopes = explode(' ', $scopes);
             }
-            if (!in_array('update', $scopes)) {
+            if (! in_array('update', $scopes)) {
                 $micropubResponses = new MicropubResponses();
 
                 return $micropubResponses->insufficientScopeResponse();

--- a/app/Http/Controllers/MicropubController.php
+++ b/app/Http/Controllers/MicropubController.php
@@ -13,6 +13,7 @@ use App\Services\Micropub\UpdateService;
 use App\Services\TokenService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use illuminate\Support\Arr;
 use Lcobucci\JWT\Encoding\CannotDecodeContent;
 use Lcobucci\JWT\Token\InvalidTokenStructure;
 use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
@@ -67,7 +68,12 @@ class MicropubController extends Controller
         $this->logMicropubRequest($request->all());
 
         if (($request->input('h') === 'entry') || ($request->input('type.0') === 'h-entry')) {
-            if (stripos($tokenData->claims()->get('scope'), 'create') === false) {
+            $scopes = $tokenData->claims()->get('scope');
+            if (is_string($scopes)) {
+                $scopes = explode(' ', $scopes);
+            }
+
+            if (!in_array('create', $scopes)) {
                 $micropubResponses = new MicropubResponses();
 
                 return $micropubResponses->insufficientScopeResponse();
@@ -81,7 +87,11 @@ class MicropubController extends Controller
         }
 
         if ($request->input('h') === 'card' || $request->input('type.0') === 'h-card') {
-            if (stripos($tokenData->claims()->get('scope'), 'create') === false) {
+            $scopes = $tokenData->claims()->get('scope');
+            if (is_string($scopes)) {
+                $scopes = explode(' ', $scopes);
+            }
+            if (!in_array('create', $scopes)) {
                 $micropubResponses = new MicropubResponses();
 
                 return $micropubResponses->insufficientScopeResponse();
@@ -95,7 +105,11 @@ class MicropubController extends Controller
         }
 
         if ($request->input('action') === 'update') {
-            if (stripos($tokenData->claims()->get('scope'), 'update') === false) {
+            $scopes = $tokenData->claims()->get('scope');
+            if (is_string($scopes)) {
+                $scopes = explode(' ', $scopes);
+            }
+            if (!in_array('update', $scopes)) {
                 $micropubResponses = new MicropubResponses();
 
                 return $micropubResponses->insufficientScopeResponse();

--- a/app/Http/Controllers/MicropubMediaController.php
+++ b/app/Http/Controllers/MicropubMediaController.php
@@ -17,7 +17,6 @@ use Illuminate\Http\Response;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 use Intervention\Image\ImageManager;
 use Lcobucci\JWT\Token\InvalidTokenStructure;
 use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
@@ -55,7 +54,7 @@ class MicropubMediaController extends Controller
         if (is_string($scopes)) {
             $scopes = explode(' ', $scopes);
         }
-        if (!in_array('create', $scopes)) {
+        if (! in_array('create', $scopes)) {
             $micropubResponses = new MicropubResponses();
 
             return $micropubResponses->insufficientScopeResponse();
@@ -127,7 +126,7 @@ class MicropubMediaController extends Controller
         if (is_string($scopes)) {
             $scopes = explode(' ', $scopes);
         }
-        if (!in_array('create', $scopes)) {
+        if (! in_array('create', $scopes)) {
             $micropubResponses = new MicropubResponses();
 
             return $micropubResponses->insufficientScopeResponse();

--- a/app/Http/Controllers/MicropubMediaController.php
+++ b/app/Http/Controllers/MicropubMediaController.php
@@ -51,7 +51,11 @@ class MicropubMediaController extends Controller
             return $micropubResponses->tokenHasNoScopeResponse();
         }
 
-        if (Str::contains($tokenData->claims()->get('scope'), 'create') === false) {
+        $scopes = $tokenData->claims()->get('scope');
+        if (is_string($scopes)) {
+            $scopes = explode(' ', $scopes);
+        }
+        if (!in_array('create', $scopes)) {
             $micropubResponses = new MicropubResponses();
 
             return $micropubResponses->insufficientScopeResponse();
@@ -119,7 +123,11 @@ class MicropubMediaController extends Controller
             return $micropubResponses->tokenHasNoScopeResponse();
         }
 
-        if (Str::contains($tokenData->claims()->get('scope'), 'create') === false) {
+        $scopes = $tokenData->claims()->get('scope');
+        if (is_string($scopes)) {
+            $scopes = explode(' ', $scopes);
+        }
+        if (!in_array('create', $scopes)) {
             $micropubResponses = new MicropubResponses();
 
             return $micropubResponses->insufficientScopeResponse();

--- a/tests/TestToken.php
+++ b/tests/TestToken.php
@@ -14,8 +14,8 @@ trait TestToken
         return $config->builder()
             ->issuedAt(new DateTimeImmutable())
             ->withClaim('client_id', 'https://quill.p3k.io')
-            ->withClaim('me', 'https://jonnybarnes.localhost')
-            ->withClaim('scope', 'create update')
+            ->withClaim('me', 'http://jonnybarnes.localhost')
+            ->withClaim('scope', ['create', 'update'])
             ->getToken($config->signer(), $config->signingKey())
             ->toString();
     }


### PR DESCRIPTION
Whether the scopes are defined as a space separated string, or an array, we should now be checking them without any errors.